### PR TITLE
[TASK] Update WrapRemoverImplementation to work on master

### DIFF
--- a/Classes/M12/Utils/TypoScript/WrapRemoverImplementation.php
+++ b/Classes/M12/Utils/TypoScript/WrapRemoverImplementation.php
@@ -53,7 +53,7 @@ class WrapRemoverImplementation extends AbstractTypoScriptObject {
 	 */
 	public function getContentCollectionNode() {
 		$currentContext = $this->tsRuntime->getCurrentContext();
-		return $currentContext['contentCollectionNode'];
+		return $currentContext['node'];
 	}
 
 	/**


### PR DESCRIPTION
`contentCollectionNode` TypoScript varaible was renamed to `node`
in https://review.typo3.org/#/c/36830/
